### PR TITLE
Add comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+/.idea/
 .DS_Store

--- a/TODO
+++ b/TODO
@@ -1,3 +1,4 @@
 Look at all the stuff that can be found in the issues
-Color picker
+Kinda done (still looks ugly as all hell) // Color picker
 Content in iframes (if possible?)
+Make popup prettier

--- a/TODO
+++ b/TODO
@@ -1,4 +1,3 @@
 Look at all the stuff that can be found in the issues
 Color picker
 Content in iframes (if possible?)
-Add a way to configure the most important colors (text, background, 2nd background, button, 2nd button) from the menu

--- a/TODO
+++ b/TODO
@@ -1,0 +1,4 @@
+Look at all the stuff that can be found in the issues
+Color picker
+Content in iframes (if possible?)
+Add a way to configure the most important colors (text, background, 2nd background, button, 2nd button) from the menu

--- a/browser-action/background.js
+++ b/browser-action/background.js
@@ -6,13 +6,13 @@ function startBackgroundCheckingProcess() {
 
 /**
  * Right now, neither 'browser' or 'browser.contentScripts' exists.
- * The appropriate name for 'browser' is 'chromium' for chromium-based browsers, and 'browser.contentScripts' does not
+ * The appropriate name for 'browser' is 'chrome' for chromium-based browsers, and 'browser.contentScripts' does not
  * exist.
- * Solutions to the first problem could be: use a polyfill that makes 'browser' resolve to 'chromium' in chromium-based browsers (see https://github.com/mozilla/webextension-polyfill),
+ * Solutions to the first problem could be: use a polyfill that makes 'browser' resolve to 'chrome' in chromium-based browsers (see https://github.com/mozilla/webextension-polyfill),
  * creating a separate background.js (and manifest.json?) for chromium-based browsers
  *
- * Solutions to the second problem could be: use a polyfill that adds an equivalent of 'browser.contentScripts' for chromium-based (see https://github.com/fregante/content-scripts-register-polyfill)
- * browsers, or creating a separate background.js (and manifest.json?) for chromium-based browsers
+ * Solutions to the second problem could be: use a polyfill that adds an equivalent of 'browser.contentScripts' for chromium-based
+ * browsers (see https://github.com/fregante/content-scripts-register-polyfill), or creating a separate background.js (and manifest.json?) for chromium-based browsers
  */
 function checkDarkModeEnabled(){
     getAll().then(results => {

--- a/browser-action/background.js
+++ b/browser-action/background.js
@@ -1,0 +1,26 @@
+const contentScriptContainer = {};
+
+function startBackgroundCheckingProcess() {
+    setInterval(checkDarkModeEnabled, 1000);
+}
+
+function checkDarkModeEnabled(){
+    getAll().then(results => {
+        if (results.darkmode && !contentScriptContainer.contentScript) {
+            browser.contentScripts.register({
+                matches: ['https://*.instructure.com/*'],
+                css: [{file: '/content-scripts/canvas/main.css'}],
+                runAt: 'document_start'
+            }).then(value => {
+                contentScriptContainer.contentScript = value;
+            });
+        } else if (!results.darkmode &&  contentScriptContainer.contentScript) {
+            contentScriptContainer.contentScript.unregister().then(() => {
+                contentScriptContainer.contentScript = undefined;
+            });
+        }
+    })
+}
+
+checkDarkModeEnabled();
+startBackgroundCheckingProcess();

--- a/browser-action/background.js
+++ b/browser-action/background.js
@@ -4,6 +4,16 @@ function startBackgroundCheckingProcess() {
     setInterval(checkDarkModeEnabled, 1000);
 }
 
+/**
+ * Right now, neither 'browser' or 'browser.contentScripts' exists.
+ * The appropriate name for 'browser' is 'chromium' for chromium-based browsers, and 'browser.contentScripts' does not
+ * exist.
+ * Solutions to the first problem could be: use a polyfill that makes 'browser' resolve to 'chromium' in chromium-based browsers (see https://github.com/mozilla/webextension-polyfill),
+ * creating a separate background.js (and manifest.json?) for chromium-based browsers
+ *
+ * Solutions to the second problem could be: use a polyfill that adds an equivalent of 'browser.contentScripts' for chromium-based (see https://github.com/fregante/content-scripts-register-polyfill)
+ * browsers, or creating a separate background.js (and manifest.json?) for chromium-based browsers
+ */
 function checkDarkModeEnabled(){
     getAll().then(results => {
         if (results.darkmode && !contentScriptContainer.contentScript) {

--- a/browser-action/background.js
+++ b/browser-action/background.js
@@ -10,7 +10,8 @@ function checkDarkModeEnabled(){
             browser.contentScripts.register({
                 matches: ['https://*.instructure.com/*'],
                 css: [{file: '/content-scripts/canvas/main.css'}],
-                runAt: 'document_start'
+                runAt: 'document_start',
+                allFrames: true
             }).then(value => {
                 contentScriptContainer.contentScript = value;
             });

--- a/browser-action/popup.html
+++ b/browser-action/popup.html
@@ -7,6 +7,7 @@
 
 <body>
 <h1> Canvas2 </h1>
+<input id="enabled" type="checkbox"> Enable dark mode
 <table>
     <tr>
         <td>Background color</td>
@@ -22,6 +23,7 @@
 
     <button id="submit">Save settings</button>
 </article>
+<script src="/common/common.js"></script>
 <script src="/browser-action/popup.js"></script>
 </body>
 </html>

--- a/browser-action/popup.html
+++ b/browser-action/popup.html
@@ -1,15 +1,27 @@
+<!DOCTYPE html>
 <html>
-  <head>
+<head>
     <title> Canvas2 </title>
-  </head>
+    <meta charset="utf-8"/>
+</head>
 
-  <body>
-    <h1> Canvas2 </h1>
-    <article>
-      <section>
-        <h2> Developer message </h2>
-        <p> This is a development version of the redesigned version of the Dark Mode for Canvas web extension. This is not ready for official release.</p>
-      </section>
-    </article>
-  </body>
+<body>
+<h1> Canvas2 </h1>
+<table>
+    <tr>
+        <td>Background color</td>
+        <td>Text color</td>
+    </tr>
+    <tr>
+        <td><label for="background-color"></label><input id="background-color"></td>
+        <td><label for="text-color"></label><input id="text-color">
+        </td>
+    </tr>
+</table>
+<article>
+
+    <button id="submit">Save settings</button>
+</article>
+<script src="/browser-action/popup.js"></script>
+</body>
 </html>

--- a/browser-action/popup.js
+++ b/browser-action/popup.js
@@ -1,0 +1,22 @@
+const bgField = document.querySelector('#background-color');
+const txtField = document.querySelector('#text-color');
+const submit = document.querySelector('#submit');
+
+function setDefaults() {
+    const bgValue = browser.storage.sync.get(['backgroundcolor', 'textcolor']);
+    bgValue.then(result => {
+        bgField.value = result.backgroundcolor || '#000000';
+        txtField.value = result.textcolor || '#FFFFFF';
+    });
+
+
+}
+
+function saveAll() {
+    browser.storage.sync.set({backgroundcolor: bgField.value});
+    browser.storage.sync.set({textcolor: txtField.value});
+    browser.tabs.reload();
+}
+
+document.addEventListener('DOMContentLoaded', setDefaults);
+submit.addEventListener('click', saveAll);

--- a/browser-action/popup.js
+++ b/browser-action/popup.js
@@ -3,16 +3,13 @@ const txtField = document.querySelector('#text-color');
 const submitButton = document.querySelector('#submit');
 const enabledCheckbox = document.querySelector('#enabled');
 
+let contentScript;
+
 function setDefaults() {
-    const stringQuery = storage.get(keys);
-    stringQuery.then(results => {
-        bgField.value = results.backgroundcolor || defaultBackgroundColor;
-        txtField.value = results.textcolor || defaultTextColor;
-        if (results.darkmode !== undefined) {
-            enabledCheckbox.checked = results.darkmode;
-        } else {
-            enabledCheckbox.checked = defaultDarkMode;
-        }
+    getAll().then(results => {
+        bgField.value = results.backgroundcolor;
+        txtField.value = results.textcolor;
+        enabledCheckbox.checked = results.darkmode;
     });
 
 }
@@ -21,22 +18,6 @@ async function saveAll() {
     storage.set({backgroundcolor: bgField.value});
     storage.set({textcolor: txtField.value});
     storage.set({darkmode: enabledCheckbox.checked});
-
-/*
-    if (enabledCheckbox.checked) {
-        browser.contentScripts.register({
-            matches: ['https://!*.instructure.com/!*'],
-            css: [{file: '/content-scripts/canvas/main.css'}],
-            runAt: 'document_start'
-        }).then(value => {
-            contentScript = value;
-            console.log(value);
-        });
-    } else if (contentScript) {
-        contentScript.unregister().then(() => console.log('Unregistered the content script'));
-    }
-*/
-
     // browser.tabs.reload(); // to reload the page automatically when settings are saved. Should probably not be enabled
 }
 

--- a/browser-action/popup.js
+++ b/browser-action/popup.js
@@ -1,22 +1,44 @@
 const bgField = document.querySelector('#background-color');
 const txtField = document.querySelector('#text-color');
-const submit = document.querySelector('#submit');
+const submitButton = document.querySelector('#submit');
+const enabledCheckbox = document.querySelector('#enabled');
 
 function setDefaults() {
-    const bgValue = browser.storage.sync.get(['backgroundcolor', 'textcolor']);
-    bgValue.then(result => {
-        bgField.value = result.backgroundcolor || '#000000';
-        txtField.value = result.textcolor || '#FFFFFF';
+    const stringQuery = storage.get(keys);
+    stringQuery.then(results => {
+        bgField.value = results.backgroundcolor || defaultBackgroundColor;
+        txtField.value = results.textcolor || defaultTextColor;
+        if (results.darkmode !== undefined) {
+            enabledCheckbox.checked = results.darkmode;
+        } else {
+            enabledCheckbox.checked = defaultDarkMode;
+        }
     });
-
 
 }
 
-function saveAll() {
-    browser.storage.sync.set({backgroundcolor: bgField.value});
-    browser.storage.sync.set({textcolor: txtField.value});
-    browser.tabs.reload();
+async function saveAll() {
+    storage.set({backgroundcolor: bgField.value});
+    storage.set({textcolor: txtField.value});
+    storage.set({darkmode: enabledCheckbox.checked});
+
+/*
+    if (enabledCheckbox.checked) {
+        browser.contentScripts.register({
+            matches: ['https://!*.instructure.com/!*'],
+            css: [{file: '/content-scripts/canvas/main.css'}],
+            runAt: 'document_start'
+        }).then(value => {
+            contentScript = value;
+            console.log(value);
+        });
+    } else if (contentScript) {
+        contentScript.unregister().then(() => console.log('Unregistered the content script'));
+    }
+*/
+
+    // browser.tabs.reload(); // to reload the page automatically when settings are saved. Should probably not be enabled
 }
 
 document.addEventListener('DOMContentLoaded', setDefaults);
-submit.addEventListener('click', saveAll);
+submitButton.addEventListener('click', saveAll);

--- a/browser-action/popup/popup.html
+++ b/browser-action/popup/popup.html
@@ -24,6 +24,6 @@
     <button id="submit">Save settings</button>
 </article>
 <script src="/common/common.js"></script>
-<script src="/browser-action/popup.js"></script>
+<script src="/browser-action/popup/popup.js"></script>
 </body>
 </html>

--- a/browser-action/popup/popup.js
+++ b/browser-action/popup/popup.js
@@ -13,7 +13,7 @@ function setDefaults() {
 }
 
 async function saveAll() {
-    setAll(bgField.value, txtField.value, enabledCheckbox.checked)
+    set(bgField.value, txtField.value, enabledCheckbox.checked)
     // browser.tabs.reload(); // to reload the page automatically when settings are saved. Should probably not be enabled
 }
 

--- a/browser-action/popup/popup.js
+++ b/browser-action/popup/popup.js
@@ -3,8 +3,6 @@ const txtField = document.querySelector('#text-color');
 const submitButton = document.querySelector('#submit');
 const enabledCheckbox = document.querySelector('#enabled');
 
-let contentScript;
-
 function setDefaults() {
     getAll().then(results => {
         bgField.value = results.backgroundcolor;
@@ -15,9 +13,7 @@ function setDefaults() {
 }
 
 async function saveAll() {
-    storage.set({backgroundcolor: bgField.value});
-    storage.set({textcolor: txtField.value});
-    storage.set({darkmode: enabledCheckbox.checked});
+    setAll(bgField.value, txtField.value, enabledCheckbox.checked)
     // browser.tabs.reload(); // to reload the page automatically when settings are saved. Should probably not be enabled
 }
 

--- a/common/common.js
+++ b/common/common.js
@@ -4,6 +4,9 @@ const defaultTextColor = '#ffffff';
 const defaultDarkMode = true;
 const keys = ['backgroundcolor', 'textcolor', 'darkmode'];
 
+/**
+ * A class that contains all the configuration options for this extension
+ */
 class CanvasDarkModeConfiguration {
     backgroundcolor;
     textcolor;

--- a/common/common.js
+++ b/common/common.js
@@ -1,0 +1,7 @@
+const storage = browser.storage.local;
+const defaultBackgroundColor = '#000000';
+const defaultTextColor = '#ffffff';
+const defaultDarkMode = true;
+const keys = ['backgroundcolor', 'textcolor', 'darkmode'];
+
+console.log("Hello")

--- a/common/common.js
+++ b/common/common.js
@@ -4,9 +4,20 @@ const defaultTextColor = '#ffffff';
 const defaultDarkMode = true;
 const keys = ['backgroundcolor', 'textcolor', 'darkmode'];
 
+class CanvasDarkModeConfiguration {
+    backgroundcolor;
+    textcolor;
+    darkmode;
+}
+
+/**
+ * Will return a promise that resolves to a CanvasDarkModeConfiguration,
+ * containing either the saved values or the default value for each respective field
+ * @returns {Promise<CanvasDarkModeConfiguration>}
+ */
 async function getAll() {
     const values = await storage.get(keys);
-    const realValues = {};
+    const realValues = new CanvasDarkModeConfiguration();
     realValues.backgroundcolor = values.backgroundcolor || defaultBackgroundColor;
     realValues.textcolor = values.textcolor || defaultTextColor;
     if (values.darkmode !== undefined) {
@@ -19,8 +30,21 @@ async function getAll() {
     });
 }
 
-function setAll(bgColor = defaultBackgroundColor, txtColor = defaultTextColor, dm = defaultDarkMode) {
-    storage.set({backgroundcolor: bgColor});
-    storage.set({textcolor: txtColor});
-    storage.set({darkmode: dm});
+/**
+ * Set the stored values. If they are left out, no changes are made
+ * @param bgColor A hex string describing the primary background color
+ * @param txtColor A hex string describing the primary text color
+ * @param dm A boolean describing whether or not the dark mode should be enabled
+ */
+
+function set(bgColor, txtColor, dm) {
+    if (bgColor) {
+        storage.set({backgroundcolor: bgColor});
+    }
+    if (txtColor) {
+        storage.set({textcolor: txtColor});
+    }
+    if (dm) {
+        storage.set({darkmode: dm});
+    }
 }

--- a/common/common.js
+++ b/common/common.js
@@ -4,17 +4,23 @@ const defaultTextColor = '#ffffff';
 const defaultDarkMode = true;
 const keys = ['backgroundcolor', 'textcolor', 'darkmode'];
 
-async function getAll(){
+async function getAll() {
     const values = await storage.get(keys);
     const realValues = {};
     realValues.backgroundcolor = values.backgroundcolor || defaultBackgroundColor;
     realValues.textcolor = values.textcolor || defaultTextColor;
-    if (values.darkmode !== undefined){
+    if (values.darkmode !== undefined) {
         realValues.darkmode = values.darkmode;
     } else {
         realValues.darkmode = defaultDarkMode;
     }
     return new Promise((resolve) => {
         resolve(realValues);
-    })
+    });
+}
+
+function setAll(bgColor = defaultBackgroundColor, txtColor = defaultTextColor, dm = defaultDarkMode) {
+    storage.set({backgroundcolor: bgColor});
+    storage.set({textcolor: txtColor});
+    storage.set({darkmode: dm});
 }

--- a/common/common.js
+++ b/common/common.js
@@ -3,3 +3,18 @@ const defaultBackgroundColor = '#000000';
 const defaultTextColor = '#ffffff';
 const defaultDarkMode = true;
 const keys = ['backgroundcolor', 'textcolor', 'darkmode'];
+
+async function getAll(){
+    const values = await storage.get(keys);
+    const realValues = {};
+    realValues.backgroundcolor = values.backgroundcolor || defaultBackgroundColor;
+    realValues.textcolor = values.textcolor || defaultTextColor;
+    if (values.darkmode !== undefined){
+        realValues.darkmode = values.darkmode;
+    } else {
+        realValues.darkmode = defaultDarkMode;
+    }
+    return new Promise((resolve) => {
+        resolve(realValues);
+    })
+}

--- a/common/common.js
+++ b/common/common.js
@@ -3,5 +3,3 @@ const defaultBackgroundColor = '#000000';
 const defaultTextColor = '#ffffff';
 const defaultDarkMode = true;
 const keys = ['backgroundcolor', 'textcolor', 'darkmode'];
-
-console.log("Hello")

--- a/content-scripts/about.html
+++ b/content-scripts/about.html
@@ -1,6 +1,8 @@
 <html>
   <head>
     <title> About Content Scripts </title>
+    <script src="/common/common.js"></script>
+    <script src="/content-scripts/canvas/main.js"></script>
   </head>
   <body>
     <article>

--- a/content-scripts/about.html
+++ b/content-scripts/about.html
@@ -1,8 +1,6 @@
 <html>
   <head>
     <title> About Content Scripts </title>
-    <script src="/common/common.js"></script>
-    <script src="/content-scripts/canvas/main.js"></script>
   </head>
   <body>
     <article>

--- a/content-scripts/canvas/main.css
+++ b/content-scripts/canvas/main.css
@@ -6,82 +6,111 @@
   --canvas-primary-button-color: #303030;
   --canvas-secondary-button-color: #606060;
 }
+/**
+  Background and text colors
+  Sets the default for all important classes
+ */
 html,
 body,
 header,
 .ic-Dashboard-header__layout,
 div.event-details::after
 {
-  background: var(--canvas-primary-background-color) !important;
-  background-color: var(--canvas-primary-background-color) !important;
-  color: var(--canvas-primary-text-color) !important;
+  background: var(--canvas-primary-background-color);
+  background-color: var(--canvas-primary-background-color);
+  color: var(--canvas-primary-text-color);
 }
 
+/**
+  Set the background color of the logo in the top-left
+ */
 a.ic-app-header__logomark
 {
-  background-color: var(--canvas-primary-background-color) !important;
+  background-color: var(--canvas-primary-background-color);
 }
 
+/**
+  Set the text color of all hyperlinks
+ */
 a
 {
-  color: var(--canvas-primary-text-color) !important;
+  color: var(--canvas-primary-text-color) ;
 }
 
+/**
+  Align all the text in headers, the dashboard header and todo-lists to the center
+ */
 header,
 .ic-Dashboard-header__layout,
 h2.todo-list-header
 {
-  text-align: center !important;
+  text-align: center ;
 }
 
+/**
+  Center text ("Recent feedback") by expanding it to 100% and centering the text
+ */
 #right-side .shared-space h2
 {
-  margin-left: 64px !important; /* had to align it using margins b/c text-align didn't work :( */
+  width: 100%;
+  text-align: center;
 }
 
-svg path
-{
-  fill: var(--canvas-primary-text-color) !important;
-}
-
-.ic-app-header__menu-list-item--active a div svg path
-{
-  fill: black !important;
-}
-
+/**
+  Recolor button below "recent feedback", color picker and one other element
+ */
 .Button.button-sidebar-wide,
 #ColorPicker__Apply,
 .fOyUs_bGBk.fOyUs_fKyb.fOyUs_cuDs.fOyUs_cBHs.fOyUs_eWbJ.fOyUs_fmDy.fOyUs_eeJl.fOyUs_cBtr.fOyUs_fuTR.fOyUs_cnfU.fQfxa_bGBk
 {
-  background-color: var(--canvas-primary-button-color) !important;
-  color: var(--canvas-primary-text-color) !important;
-  text-align: center !important;
-  border: 2px solid white !important;
-  transition: background-color .2s !important;
+  background-color: var(--canvas-primary-button-color) ;
+  color: var(--canvas-primary-text-color) ;
+  text-align: center ;
+  border: 2px solid white ;
+  transition: background-color .2s ;
 }
 
-.Button.button-sidebar-wide:hover
+/**
+  Adjust the background color of the button, color picker and one other element on hover
+ */
+.Button.button-sidebar-wide:hover,
 #ColorPicker__Apply:hover,
 .fOyUs_bGBk.fOyUs_fKyb.fOyUs_cuDs.fOyUs_cBHs.fOyUs_eWbJ.fOyUs_fmDy.fOyUs_eeJl.fOyUs_cBtr.fOyUs_fuTR.fOyUs_cnfU.fQfxa_bGBk:hover
 {
-  background-color: var(--canvas-secondary-button-color) !important;
+  background-color: var(--canvas-secondary-button-color) ;
+}
+
+/**
+  Make the SVG logos white
+ */
+svg path
+{
+  fill: var(--canvas-primary-text-color) ;
+}
+
+/**
+  Make the active SVG the correct color
+ */
+.ic-app-header__menu-list-item--active a div svg path
+{
+  fill: var(--canvas-primary-text-color) ;
 }
 
 .ic-DashboardCard,
 .ic-DashboardCard__header_content
 {
-  background: var(--canvas-primary-button-color) !important;
+  background: var(--canvas-primary-button-color) ;
 }
 
 .ic-DashboardCard__header-subtitle,
 .ic-DashboardCard__header-term
 {
-  color: var(--canvas-primary-text-color) !important;
+  color: var(--canvas-primary-text-color) ;
 }
 
 .fOyUs_bGBk.fOyUs_dnJm.fOyUs_tIxX.fOyUs_EMjX.fOyUs_kXoP.fOyUs_UeJS.fOyUs_bxuL.dqmEK_caGd
 {
-  -webkit-filter: invert(100%) hue-rotate(180deg)!important;
+  -webkit-filter: invert(100%) hue-rotate(180deg);
 }
 
 
@@ -91,5 +120,5 @@ span.fQfxa_eoCh svg,
 #ColorPicker__Apply,
 .fOyUs_bGBk.fOyUs_fKyb.fOyUs_cuDs.fOyUs_cBHs.fOyUs_eWbJ.fOyUs_fmDy.fOyUs_eeJl.fOyUs_cBtr.fOyUs_fuTR.fOyUs_cnfU.fQfxa_bGBk
 {
-  -webkit-filter: invert(100%) hue-rotate(180deg)!important;
+  -webkit-filter: invert(100%) hue-rotate(180deg);
 }

--- a/content-scripts/canvas/main.css
+++ b/content-scripts/canvas/main.css
@@ -146,17 +146,17 @@ svg path {
     background: var(--canvas-primary-button-color) !important;
 }
 
-/*.fOyUs_bGBk.fOyUs_dnJm.fOyUs_tIxX.fOyUs_EMjX.fOyUs_kXoP.fOyUs_UeJS.fOyUs_bxuL.dqmEK_caGd*/
-/*{*/
-/*  -webkit-filter: invert(100%) hue-rotate(180deg);*/
-/*}*/
+.fOyUs_bGBk.fOyUs_dnJm.fOyUs_tIxX.fOyUs_EMjX.fOyUs_kXoP.fOyUs_UeJS.fOyUs_bxuL.dqmEK_caGd
+{
+  -webkit-filter: invert(100%) hue-rotate(180deg);
+}
 
 
 /*!* weird shit going on here with the color picker menu on dashboard - the close button inverts whenever the Cancel button isn't and vice versa *!*/
-/*span.fQfxa_eoCh svg,*/
-/*.esvoZ_bGBk.esvoZ_drOs.esvoZ_eXrk.cGqzL_bGBk.DashboardCardMenu__MovementIcon,*/
-/*#ColorPicker__Apply,*/
-/*.ToDoSidebarItem__Close span button*/
-/*{*/
-/*  -webkit-filter: invert(100%) hue-rotate(180deg);*/
-/*}*/
+span.fQfxa_eoCh svg,
+.esvoZ_bGBk.esvoZ_drOs.esvoZ_eXrk.cGqzL_bGBk.DashboardCardMenu__MovementIcon,
+#ColorPicker__Apply,
+.ToDoSidebarItem__Close span button
+{
+  -webkit-filter: invert(100%) hue-rotate(180deg);
+}

--- a/content-scripts/canvas/main.css
+++ b/content-scripts/canvas/main.css
@@ -1,124 +1,159 @@
 /* when adding theme options, don't remove this html CSS. Keep it as is */
-:root
-{
-  --canvas-primary-background-color: black;
-  --canvas-primary-text-color: white;
-  --canvas-primary-button-color: #303030;
-  --canvas-secondary-button-color: #606060;
+:root {
+    --canvas-primary-background-color: black;
+    --canvas-primary-text-color: white;
+    --canvas-primary-button-color: #303030;
+    --canvas-secondary-button-color: #606060;
+    --canvas-secondary-background-color: #606060;
 }
-/**
+
+/*
   Background and text colors
-  Sets the default for all important classes
+  Sets the default for all important elements
  */
 html,
 body,
 header,
-.ic-Dashboard-header__layout,
-div.event-details::after
-{
-  background: var(--canvas-primary-background-color);
-  background-color: var(--canvas-primary-background-color);
-  color: var(--canvas-primary-text-color);
+.navigation-tray-container,
+#content,
+#content :not(.ic-DashboardCard__header_hero):not(.ic-DashboardCard__header-button-bg):not(.ic-DashboardCard__header-button):not(.ic-DashboardCard__header-button-bg):not(.icon-more),
+#content button:not(.ic-DashboardCard__header-button),
+#breadcrumbs,
+.ui-dialog,
+.ui-dialog *,
+#NicknameInput,
+span[dir="ltr"],
+span[dir="ltr"] > * :not(.ColorPicker__ColorBlock):not(.icon-check):not(.ColorPicker__ColorPreview),
+#right-side {
+    background: var(--canvas-primary-background-color) !important;
+    background-color: var(--canvas-primary-background-color) !important;
+    color: var(--canvas-primary-text-color) !important;
 }
 
-/**
+/*
   Set the background color of the logo in the top-left
  */
-a.ic-app-header__logomark
-{
-  background-color: var(--canvas-primary-background-color);
+a.ic-app-header__logomark {
+    background-color: var(--canvas-primary-background-color) !important;
 }
 
-/**
-  Set the text color of all hyperlinks
+/*
+  Set the text color of all hyperlinks, their children, and some elements that act as hyperlinks but are really just buttons
  */
-a
-{
-  color: var(--canvas-primary-text-color) ;
+/* All hyperlinks */
+a,
+    /* links on right-hand side */
+.right-side-wrapper a,
+    /* hamburger icon of navigation menu on left-hand side */
+.icon-hamburger,
+    /* Some icons, specifically those on the "grades" page */
+.standalone-icon::before {
+    color: var(--canvas-primary-text-color) !important;
 }
 
-/**
+/*
+  Set the hovering behaviour of all hyperlinks, all children of hyperlinks, and hyperlinks that ignore this rule
+ */
+a:hover,
+.right-side-wrapper a:hover,
+    /* The text in the button below the todo sidebar */
+button:hover span {
+    color: var(--canvas-primary-text-color) !important;
+    text-decoration: underline !important;;
+    text-decoration-color: var(--canvas-primary-text-color) !important;;
+}
+
+/* Set background color of "log out" button and additional navigation buttons on the right side */
+.tray-with-space-for-global-nav form button span,
+.btn.button-sidebar-wide {
+    background-color: var(--canvas-primary-background-color) !important;
+}
+
+/*
+    Set active list-view item background color
+ */
+.list-view .section .active {
+    background-color: var(--canvas-secondary-background-color) !important;
+}
+
+/* To fix search button on the discussions page */
+.discussions-v2_wrapper span > span > span {
+    background: none !important;
+}
+
+/*
   Align all the text in headers, the dashboard header and todo-lists to the center
  */
 header,
 .ic-Dashboard-header__layout,
-h2.todo-list-header
-{
-  text-align: center ;
+h2.todo-list-header {
+    text-align: center !important;
 }
 
-/**
+/*
   Center text ("Recent feedback") by expanding it to 100% and centering the text
  */
-#right-side .shared-space h2
-{
-  width: 100%;
-  text-align: center;
+#right-side .shared-space h2 {
+    width: 100% !important;
+    text-align: center !important;
 }
 
-/**
-  Recolor button below "recent feedback", color picker and one other element
+/*
+  Recolor button "View Grades", color picker and one other element
  */
-.Button.button-sidebar-wide,
+#right-side a.Button.button-sidebar-wide,
 #ColorPicker__Apply,
-.fOyUs_bGBk.fOyUs_fKyb.fOyUs_cuDs.fOyUs_cBHs.fOyUs_eWbJ.fOyUs_fmDy.fOyUs_eeJl.fOyUs_cBtr.fOyUs_fuTR.fOyUs_cnfU.fQfxa_bGBk
-{
-  background-color: var(--canvas-primary-button-color) ;
-  color: var(--canvas-primary-text-color) ;
-  text-align: center ;
-  border: 2px solid white ;
-  transition: background-color .2s ;
+#right-side-wrapper button {
+    background-color: var(--canvas-primary-button-color);
+    color: var(--canvas-primary-text-color);
+    text-align: center;
+    border: 2px solid white;
+    transition: background-color .2s;
 }
 
-/**
-  Adjust the background color of the button, color picker and one other element on hover
+/*
+  Adjust the background color of the button, color picker and all right-hand side buttons
  */
-.Button.button-sidebar-wide:hover,
+#right-side a.Button.button-sidebar-wide:hover,
 #ColorPicker__Apply:hover,
-.fOyUs_bGBk.fOyUs_fKyb.fOyUs_cuDs.fOyUs_cBHs.fOyUs_eWbJ.fOyUs_fmDy.fOyUs_eeJl.fOyUs_cBtr.fOyUs_fuTR.fOyUs_cnfU.fQfxa_bGBk:hover
-{
-  background-color: var(--canvas-secondary-button-color) ;
+#right-side-wrapper button:hover {
+    background-color: var(--canvas-secondary-button-color);
 }
 
-/**
-  Make the SVG logos white
+/*
+  Make SVG logos the primary text color
  */
-svg path
-{
-  fill: var(--canvas-primary-text-color) ;
+svg path {
+    fill: var(--canvas-primary-text-color);
 }
 
-/**
-  Make the active SVG the correct color
+/*
+  Make the active SVG (in the left-hand side navigation bar) the correct, inverted color
  */
-.ic-app-header__menu-list-item--active a div svg path
-{
-  fill: var(--canvas-primary-text-color) ;
+.ic-app-header__menu-list-item--active a div svg path {
+    fill: var(--canvas-primary-background-color);
 }
+
+/*
+  Set the background color of each "dashboard card"
+ */
 
 .ic-DashboardCard,
-.ic-DashboardCard__header_content
-{
-  background: var(--canvas-primary-button-color) ;
+.ic-DashboardCard__header_content {
+    background: var(--canvas-primary-button-color) !important;
 }
 
-.ic-DashboardCard__header-subtitle,
-.ic-DashboardCard__header-term
-{
-  color: var(--canvas-primary-text-color) ;
-}
-
-.fOyUs_bGBk.fOyUs_dnJm.fOyUs_tIxX.fOyUs_EMjX.fOyUs_kXoP.fOyUs_UeJS.fOyUs_bxuL.dqmEK_caGd
-{
-  -webkit-filter: invert(100%) hue-rotate(180deg);
-}
+/*.fOyUs_bGBk.fOyUs_dnJm.fOyUs_tIxX.fOyUs_EMjX.fOyUs_kXoP.fOyUs_UeJS.fOyUs_bxuL.dqmEK_caGd*/
+/*{*/
+/*  -webkit-filter: invert(100%) hue-rotate(180deg);*/
+/*}*/
 
 
-/* weird shit going on here with the color picker menu on dashboard - the close button inverts whenever the Cancel button isn't and vice versa */
-span.fQfxa_eoCh svg,
-.esvoZ_bGBk.esvoZ_drOs.esvoZ_eXrk.cGqzL_bGBk.DashboardCardMenu__MovementIcon,
-#ColorPicker__Apply,
-.fOyUs_bGBk.fOyUs_fKyb.fOyUs_cuDs.fOyUs_cBHs.fOyUs_eWbJ.fOyUs_fmDy.fOyUs_eeJl.fOyUs_cBtr.fOyUs_fuTR.fOyUs_cnfU.fQfxa_bGBk
-{
-  -webkit-filter: invert(100%) hue-rotate(180deg);
-}
+/*!* weird shit going on here with the color picker menu on dashboard - the close button inverts whenever the Cancel button isn't and vice versa *!*/
+/*span.fQfxa_eoCh svg,*/
+/*.esvoZ_bGBk.esvoZ_drOs.esvoZ_eXrk.cGqzL_bGBk.DashboardCardMenu__MovementIcon,*/
+/*#ColorPicker__Apply,*/
+/*.ToDoSidebarItem__Close span button*/
+/*{*/
+/*  -webkit-filter: invert(100%) hue-rotate(180deg);*/
+/*}*/

--- a/content-scripts/canvas/main.css
+++ b/content-scripts/canvas/main.css
@@ -26,7 +26,7 @@ span[dir="ltr"],
 span[dir="ltr"] > * :not(.ColorPicker__ColorBlock):not(.icon-check):not(.ColorPicker__ColorPreview),
 #right-side,
 .ctf-container,
-.ctf-container * {
+.ctf-container :not(.ctf-emoji-button) {
     background: var(--canvas-primary-background-color) !important;
     background-color: var(--canvas-primary-background-color) !important;
     color: var(--canvas-primary-text-color) !important;

--- a/content-scripts/canvas/main.css
+++ b/content-scripts/canvas/main.css
@@ -9,7 +9,8 @@
 
 /*
   Background and text colors
-  Sets the default for all important elements
+  Sets the default for all important elements, while trying to not-touch those elements that require their color to remain
+  the same (like the color picker and dashboard cards)
  */
 html,
 body,

--- a/content-scripts/canvas/main.css
+++ b/content-scripts/canvas/main.css
@@ -24,7 +24,9 @@ header,
 #NicknameInput,
 span[dir="ltr"],
 span[dir="ltr"] > * :not(.ColorPicker__ColorBlock):not(.icon-check):not(.ColorPicker__ColorPreview),
-#right-side {
+#right-side,
+.ctf-container,
+.ctf-container * {
     background: var(--canvas-primary-background-color) !important;
     background-color: var(--canvas-primary-background-color) !important;
     color: var(--canvas-primary-text-color) !important;

--- a/content-scripts/canvas/main.js
+++ b/content-scripts/canvas/main.js
@@ -32,6 +32,12 @@ function injectVars(color)
   root.style.setProperty("--ic-brand-global-nav-menu-item__badge-bgd", color);
   root.style.setProperty("--ic-brand-global-nav-menu-item__badge-text", "white");
   root.style.setProperty("--ic-brand-global-nav-logo-bgd", color);
+
+  browser.storage.sync.get(["textcolor", "backgroundcolor"]).then(result =>{
+    root.style.setProperty("--canvas-primary-background-color", result.textcolor || "black")
+    root.style.setProperty("--canvas-primary-background-color", result.backgroundcolor || "white")
+  })
+
 }
 
 injectVars("black"); /* or #15202B */

--- a/content-scripts/canvas/main.js
+++ b/content-scripts/canvas/main.js
@@ -1,43 +1,54 @@
-function injectVars(color)
-{
-  let root = document.documentElement;
-
-  root.style.setProperty("--ic-brand-primary-darkened-5", color);
-  root.style.setProperty("--ic-brand-primary-darkened-10", color);
-  root.style.setProperty("--ic-brand-primary-darkened-15", color);
-  root.style.setProperty("--ic-brand-primary-lightened-5", color);
-  root.style.setProperty("--ic-brand-primary-lightened-10", color);
-  root.style.setProperty("--ic-brand-primary-lightened-15", color);
-  root.style.setProperty("--ic-brand-button--primary-bgd-darkened-5", color);
-  root.style.setProperty("--ic-brand-button--primary-bgd-darkened-15", color);
-  root.style.setProperty("--ic-brand-button--secondary-bgd-darkened-5", color);
-  root.style.setProperty("--ic-brand-button--secondary-bgd-darkened-15", color);
-  root.style.setProperty("--ic-brand-font-color-dark-lightened-15", "white");
-  root.style.setProperty("--ic-brand-font-color-dark-lightened-30", "white");
-  root.style.setProperty("--ic-link-color-darkened-10", "white");
-  root.style.setProperty("--ic-link-color-lightened-10", "white");
-  root.style.setProperty("--ic-brand-primary", color);
-  root.style.setProperty("--ic-brand-font-color-dark", "#AAA");
-  root.style.setProperty("--ic-brand-button--primary-bgd", "#303030"); /*might be screwed up*/
-  root.style.setProperty("--ic-brand-button--primary-text", "white");
-  root.style.setProperty("--ic-brand-button--secondary-bgd", "#303030"); /*might be screwed up*/
-  root.style.setProperty("--ic-brand-button--secondary-text", "white");
-  root.style.setProperty("--ic-brand-global-nav-bgd", color);
-  root.style.setProperty("--ic-brand-global-nav-ic-icon-svg-fill", "white");
-  root.style.setProperty("--ic-link-color-darkened-10", "white");
-  root.style.setProperty("--ic-brand-global-nav-ic-icon-svg-fill--active", color);
-  root.style.setProperty("--ic-brand-global-nav-menu-item__text-color", "white");
-  root.style.setProperty("--ic-brand-global-nav-menu-item__text-color--active", color);
-  root.style.setProperty("--ic-brand-global-nav-avatar-border", "white");
-  root.style.setProperty("--ic-brand-global-nav-menu-item__badge-bgd", color);
-  root.style.setProperty("--ic-brand-global-nav-menu-item__badge-text", "white");
-  root.style.setProperty("--ic-brand-global-nav-logo-bgd", color);
-
-  browser.storage.sync.get(["textcolor", "backgroundcolor"]).then(result =>{
-    root.style.setProperty("--canvas-primary-background-color", result.textcolor || "black")
-    root.style.setProperty("--canvas-primary-background-color", result.backgroundcolor || "white")
-  })
-
+console.log("bruh")
+function setProp(name, value, element = document.documentElement) {
+    element.style.setProperty(name, value);
 }
 
-injectVars("black"); /* or #15202B */
+function injectVars(backgroundColor = defaultBackgroundColor, textColor = defaultTextColor) {
+    setProp('--canvas-primary-background-color', backgroundColor);
+    setProp('--ic-brand-primary-darkened-5', backgroundColor);
+    setProp('--ic-brand-primary-darkened-10', backgroundColor);
+    setProp('--ic-brand-primary-darkened-15', backgroundColor);
+    setProp('--ic-brand-primary-lightened-5', backgroundColor);
+    setProp('--ic-brand-primary-lightened-10', backgroundColor);
+    setProp('--ic-brand-primary-lightened-15', backgroundColor);
+    setProp('--ic-brand-button--primary-bgd-darkened-5', backgroundColor);
+    setProp('--ic-brand-button--primary-bgd-darkened-15', backgroundColor);
+    setProp('--ic-brand-button--secondary-bgd-darkened-5', backgroundColor);
+    setProp('--ic-brand-button--secondary-bgd-darkened-15', backgroundColor);
+    setProp('--ic-brand-font-color-dark-lightened-15', textColor);
+    setProp('--ic-brand-font-color-dark-lightened-30', textColor);
+    setProp('--ic-link-color-darkened-10', textColor);
+    setProp('--ic-link-color-lightened-10', textColor);
+    setProp('--ic-brand-primary', backgroundColor);
+    setProp('--ic-brand-button--primary-text', textColor);
+    setProp('--ic-brand-button--secondary-text', textColor);
+    setProp('--ic-brand-global-nav-bgd', backgroundColor);
+    setProp('--ic-brand-global-nav-ic-icon-svg-fill', textColor);
+    setProp('--ic-link-color-darkened-10', textColor);
+    setProp('--ic-brand-global-nav-ic-icon-svg-fill--active', backgroundColor);
+    setProp('--ic-brand-global-nav-menu-item__text-color', textColor);
+    setProp('--ic-brand-global-nav-menu-item__text-color--active', backgroundColor);
+    setProp('--ic-brand-global-nav-avatar-border', textColor);
+    setProp('--ic-brand-global-nav-menu-item__badge-bgd', backgroundColor);
+    setProp('--ic-brand-global-nav-menu-item__badge-text', textColor);
+    setProp('--ic-brand-global-nav-logo-bgd', backgroundColor);
+    /*
+    These three are special, might need a different color?
+     */
+    setProp('--ic-brand-font-color-dark', '#AAA');
+    setProp('--ic-brand-button--primary-bgd', '#303030'); /*might be screwed up*/
+    setProp('--ic-brand-button--secondary-bgd', '#303030'); /*might be screwed up*/
+}
+
+function loadFromStorage() {
+    storage.get(keys).then(result => {
+        const darkmode = result.darkmode === undefined ? defaultDarkMode : result.darkmode;
+        if (darkmode) {
+            const bgColor = result.backgroundcolor || defaultBackgroundColor;
+            const txtColor = result.textcolor || defaultTextColor;
+            injectVars(bgColor, txtColor);
+        }
+    });
+}
+console.log("Bruh");
+loadFromStorage();

--- a/content-scripts/canvas/main.js
+++ b/content-scripts/canvas/main.js
@@ -1,4 +1,3 @@
-console.log("bruh")
 function setProp(name, value, element = document.documentElement) {
     element.style.setProperty(name, value);
 }
@@ -43,6 +42,7 @@ function injectVars(backgroundColor = defaultBackgroundColor, textColor = defaul
 function loadFromStorage() {
     storage.get(keys).then(result => {
         const darkmode = result.darkmode === undefined ? defaultDarkMode : result.darkmode;
+        console.log(darkmode);
         if (darkmode) {
             const bgColor = result.backgroundcolor || defaultBackgroundColor;
             const txtColor = result.textcolor || defaultTextColor;
@@ -50,5 +50,4 @@ function loadFromStorage() {
         }
     });
 }
-console.log("Bruh");
 loadFromStorage();

--- a/content-scripts/canvas/main.js
+++ b/content-scripts/canvas/main.js
@@ -42,7 +42,6 @@ function injectVars(backgroundColor = defaultBackgroundColor, textColor = defaul
 function loadFromStorage() {
     storage.get(keys).then(result => {
         const darkmode = result.darkmode === undefined ? defaultDarkMode : result.darkmode;
-        console.log(darkmode);
         if (darkmode) {
             const bgColor = result.backgroundcolor || defaultBackgroundColor;
             const txtColor = result.textcolor || defaultTextColor;

--- a/manifest.json
+++ b/manifest.json
@@ -25,10 +25,8 @@
   ],
   "content_scripts": [
     {
-      "css": [
-        "/content-scripts/canvas/canvas.css"
-      ],
       "js": [
+        "/common/common.js",
         "/content-scripts/canvas/main.js"
       ],
       "matches": [

--- a/manifest.json
+++ b/manifest.json
@@ -21,8 +21,15 @@
     "page": "/browser-action/popup.html"
   },
   "permissions": [
-    "storage"
+    "storage",
+    "https://*.instructure.com/*"
   ],
+  "background": {
+    "scripts": [
+      "/common/common.js",
+      "/browser-action/background.js"
+    ]
+  },
   "content_scripts": [
     {
       "js": [

--- a/manifest.json
+++ b/manifest.json
@@ -25,9 +25,10 @@
   "content_scripts":
   [
     {
+      "css": ["/content-scripts/canvas/main.css"],
       "js": ["/content-scripts/canvas/main.js"],
       "matches": ["https://*.instructure.com/*"],
-      "run-at":["document_start"]
+      "run_at": "document_start"
     }
   ]
 

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
   },
   "browser_action": {
     "default_title": "Canvas2",
-    "default_popup": "/browser-action/popup.html"
+    "default_popup": "/browser-action/popup/popup.html"
   },
   "browser_specific_settings": {
     "gecko": {
@@ -18,7 +18,7 @@
     }
   },
   "options_ui": {
-    "page": "/browser-action/popup.html"
+    "page": "/browser-action/popup/popup.html"
   },
   "permissions": [
     "storage",
@@ -32,6 +32,7 @@
   },
   "content_scripts": [
     {
+      "all_frames": true,
       "js": [
         "/common/common.js",
         "/content-scripts/canvas/main.js"

--- a/manifest.json
+++ b/manifest.json
@@ -1,35 +1,40 @@
 {
-
   "manifest_version": 2,
-
   "name": "Canvas2",
-
   "version": "2.0.0",
-
   "description": "Development version of redesigned Dark Mode for Canvas web extension.",
-
-  "icons":
-  {
+  "icons": {
     "48": "icon/48.png",
     "128": "icon/128.png",
     "512": "icon/512.png"
   },
-
-  "browser_action" :
-  {
-    "default_title" : "Canvas2",
-    "default_popup" : "/browser-action/popup.html"
+  "browser_action": {
+    "default_title": "Canvas2",
+    "default_popup": "/browser-action/popup.html"
   },
-
-
-  "content_scripts":
-  [
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "canvas2@test.com"
+    }
+  },
+  "options_ui": {
+    "page": "/browser-action/popup.html"
+  },
+  "permissions": [
+    "storage"
+  ],
+  "content_scripts": [
     {
-      "css": ["/content-scripts/canvas/main.css"],
-      "js": ["/content-scripts/canvas/main.js"],
-      "matches": ["https://*.instructure.com/*"],
+      "css": [
+        "/content-scripts/canvas/main.css"
+      ],
+      "js": [
+        "/content-scripts/canvas/main.js"
+      ],
+      "matches": [
+        "https://*.instructure.com/*"
+      ],
       "run_at": "document_start"
     }
   ]
-
 }

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,7 @@
   "content_scripts": [
     {
       "css": [
-        "/content-scripts/canvas/main.css"
+        "/content-scripts/canvas/canvas.css"
       ],
       "js": [
         "/content-scripts/canvas/main.js"


### PR DESCRIPTION
This branch adds a the following features, although, due to the usage of 'browser' instead of 'chromium' it currently only works in Firefox:

Very basic dark mode for most of the canvas-native pages
An enable/disable toggle
Configurable background color and text color
A very, very basic popup to change said options
A background service that adds and keeps track of content scripts that can be added/removed at runtime (with comments on possible approaches for getting it to work in chromium based browsers, though none of these have been tested yet)
The common.js file provides all the functionality that is required by multiple parts of the extension, and default configuration options